### PR TITLE
feat: allow experimental syntax by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,6 @@
 module.exports = {
     plugins: [
         require('babel-plugin-empower-assert'),
-        require('babel-plugin-espower')
+        require('babel-plugin-espower/with-experimental-syntax')
     ]
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/power-assert-js/babel-preset-power-assert/issues",
   "dependencies": {
     "babel-plugin-empower-assert": "^1.2.0",
-    "babel-plugin-espower": "^2.1.2"
+    "babel-plugin-espower": "^2.4.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
by changing default value of `embedAst` option to `true`

since most of babel users use experimental (not in ES-standard) syntax.

BREAKING CHANGE: Changing `embedAst` option's default to `true` does not break builds but may slow your build time down. If you are aware that you are not using experimental (not in ES-standard) syntax, please use babel-preset-power-assert 1.x for the former behavior.